### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,6 +1,6 @@
-- name: Office
+- name: Microsoft 365
   tocHref: /office/
-  topicHref: /office/index
+  topicHref: /microsoft-365/index
   items:
   - name: Developer Program
     tocHref: /office/developer-program/

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -39,7 +39,6 @@
       "uhfHeaderId": "MSDocsHeader-Dev_Office",
       "searchScope": ["Office dev program"],
       "breadcrumb_path": "/office/developer-program/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "ms.suite": "office365",
       "ms.author": "o365devx",
       "author": "o365devx",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 