### PR TITLE
Update Visual Studio subscription information

### DIFF
--- a/docs/join-with-visual-studio.md
+++ b/docs/join-with-visual-studio.md
@@ -13,9 +13,9 @@ Visual Studio subscribers with standard Professional or standard or monthly Ente
 
 ## How do I get a renewable Microsoft 365 developer subscription?
 
-If you don't have a Visual Studio standard Professional or montly or standard Enterprise subscription and you want one, see the [Visual Studio subscription](https://visualstudio.microsoft.com/vs/pricing/) page.
+If you don't have a Visual Studio Professional (standard or monthly) or Enterprise (standard or monthly) subscription and you're interested in obtaining one, please visit the [Visual Studio subscription](https://visualstudio.microsoft.com/vs/pricing/) page.
 
-If you already have a Visual Studio standard Professional or standard or monthly Enterprise subscription, after you join the program, when you set up your Microsoft 365 developer subscription, you have the option to link it to your Visual Studio subscription. For details, see [Set up your Microsoft 365 E5 sandbox subscription](microsoft-365-developer-program-get-started.md#set-up-your-microsoft-365-e5-sandbox-subscription).
+If you already hold a Visual Studio Professional (standard or monthly) or an Enterprise (standard or monthly) subscription, you will have the option to link it to your Microsoft 365 developer subscription once you join the program and begin setting it up. For more details, see [Set up your Microsoft 365 E5 sandbox subscription](microsoft-365-developer-program-get-started.md#set-up-your-microsoft-365-e5-sandbox-subscription).
 
 You can also join the Microsoft 365 Developer Program and get a Microsoft 365 developer subscription from your Visual Studio subscriber portal. Go to [Visual Studio | My Benefits](https://my.visualstudio.com/benefits) and click the **Microsoft 365 Developer subscription (E5)** tile, and you will automatically join the Microsoft 365 developer program with your Visual Studio ID. 
 


### PR DESCRIPTION
This commit corrects a typo and rephrases instructions for linking Microsoft 365 developer subscriptions with Visual Studio subscriptions.