### PR TITLE
Removing wrong information at microsoft-365-developer-program-faq.yml

### DIFF
--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -52,7 +52,7 @@ sections:
       - question: |
           Who qualifies for a Microsoft 365 E5 developer subscription?
         answer: |
-          Any Visual Studio subscriber with a standard Professional or standard or monthly Enterprise subscription qualifies for a subscription that renews automatically. We are currently piloting a new verification process that will allow more member types to qualify for a subscription. The new process will enable developer program members to request a Microsoft 365 E5 subscription, go through a validation process, and receive an invitation to set up a subscription. For the latest updates, including when the new verification process will be broadly available, follow the [Microsoft 365 developer blog](https://devblogs.microsoft.com/microsoft365dev/tag/microsoft-365-developer-program/).
+          Any Visual Studio subscriber with a standard Professional or standard Enterprise subscription qualifies for a subscription that renews automatically. We are currently piloting a new verification process that will allow more member types to qualify for a subscription. The new process will enable developer program members to request a Microsoft 365 E5 subscription, go through a validation process, and receive an invitation to set up a subscription. For the latest updates, including when the new verification process will be broadly available, follow the [Microsoft 365 developer blog](https://devblogs.microsoft.com/microsoft365dev/tag/microsoft-365-developer-program/).
       
       - question: |
           How many Microsoft 365 developer subscriptions can I get via the Developer Program?  
@@ -188,7 +188,7 @@ sections:
         answer: |
           Your subscription is good for 90 days and is renewable based on valid developer activity. If you're using your subscription for development, it will be renewed regularly. You can find the expiration date, along with your subscription name, on your [Microsoft 365 Developer Program dashboard](https://aka.ms/DevProgramDashboard).
           
-          If you're joining the program with your Visual Studio standard Professional or standard or monthly Enterprise subscription, your subscription is automatically renewed until your Visual Studio subscription expires. 
+          If you're joining the program with your Visual Studio standard Professional or standard Enterprise subscription, your subscription is automatically renewed until your Visual Studio subscription expires. 
           
           <a name="renew-subscription"> </a>
           
@@ -202,7 +202,7 @@ sections:
         answer: |
           In April 2019, we transitioned to a new model where your subscription can be renewed perpetually every 90 days if you're actively using it for development. We believe that this model ensures that developers who are actively developing solutions have a subscription for as long as they need one. If you're developing frequently, your subscription never expires; it is automatically extended. If you qualify for a subscription and you're developing for a short time, and your subscription expires due to inactivity and is deleted, you can set up a new one. 
           
-          If you prefer to have a subscription that is available for a longer time, we recommend that you get the Visual Studio standard Professional or standard or monthly Enterprise subscription. These programs include a free Microsoft 365 developer subscription that is good for the life of your Visual Studio subscription. To access this, go to [Visual Studio | My Benefits](https://my.visualstudio.com/benefits). For more information, contact [Visual Studio customer service](https://www.visualstudio.com/subscriptions/support/). 
+          If you prefer to have a subscription that is available for a longer time, we recommend that you get the Visual Studio standard Professional or standard Enterprise subscription. These programs include a free Microsoft 365 developer subscription that is good for the life of your Visual Studio subscription. To access this, go to [Visual Studio | My Benefits](https://my.visualstudio.com/benefits). For more information, contact [Visual Studio customer service](https://www.visualstudio.com/subscriptions/support/). 
           
       - question: |
           How do you determine whether a subscription can be renewed?
@@ -279,7 +279,7 @@ sections:
         answer: |
           All Developer Program members must qualify for a Microsoft 365 E5 subscription. If you're a qualified member, you'll be invited to set up a developer subscription after you join the program.
           
-          If you have a Visual Studio standard Professional or standard or monthly Enterprise subscription, you can get a Microsoft 365 developer subscription as a benefit. To access this, go to [Visual Studio | My Benefits](https://my.visualstudio.com/benefits). For more information, contact [Visual Studio customer service](https://www.visualstudio.com/subscriptions/support/). 
+          If you have a Visual Studio standard Professional or standard Enterprise subscription, you can get a Microsoft 365 developer subscription as a benefit. To access this, go to [Visual Studio | My Benefits](https://my.visualstudio.com/benefits). For more information, contact [Visual Studio customer service](https://www.visualstudio.com/subscriptions/support/). 
           
       - question: |
           As a full-time Microsoft employee, can I receive a subscription?


### PR DESCRIPTION
According to the official documentation and the pricing website, The benefit for Visual Studio Enterprise Monthly is not available, only Standard is. Customer's are complaining about the incorrect information at this page.