### PR TITLE
Update Microsoft 365 Developer Program eligibility details

### DIFF
--- a/docs/microsoft-365-developer-program.md
+++ b/docs/microsoft-365-developer-program.md
@@ -17,15 +17,14 @@ Do you have a Visual Studio Pro or Enterprise subscription? If so, you can take 
 
 Use the following quick reference to see if you are eligible.
 
->[!NOTE]
-> The Microsoft 365 Developer Program is not offered in Microsoft's government clouds such as Microsoft 365 Government (GCC, GCC High, or DoD). Government cloud environments are designed to meet specific regulatory and compliance requirements, and some programs or features available in the commercial cloud are not supported there.
 
 |**Category**                 |**Qualification**|**How to join**|**See also**|
 |:----------------------------|:----------------|:--------------|:-----------|
 | Visual Studio Subscribers   | Visual Studio Professional or Enterprise subscription holders automatically qualify. | Sign up via Visual Studio portal. | [Join now](/office/developer-program/join-with-visual-studio) |
 | ISV Success Program Members | Companies enrolled in ISV Success Program or eligible MAICPP tiers can request a Microsoft 365 E5 developer subscription. | Once you sign up for the developer program with your corporate email, the eligibility option will appear. | [- Learn more about the ISV Success Program](/partner-center/membership/isv-success)</br></br>[- Learn more about the MAICPP](https://www.microsoft.com/americas-partner-one/maicpp?msockid=111adc8963d469eb14c7c9c562866859) |
 | Microsoft AI Cloud Partner Program Participants   | Eligible MAICPP partner levels include:</br><ul><li> Azure Expert Managed Service Providers (MSP)</li><li> Solutions Partners</li><li> Specialization Partners</li><li> Managed Partners</li><li> Microsoft Action Pack Subscribers</li><li> Partner Success Core Benefits Recipients</li><li> Partner Success Expanded Benefits Recipients</li><li> Partner Launch Benefits Recipients</li><li> Legacy Gold/Silver Partners</li></ul> | Sign in with your corporate email and the eligibility option will appear. | [Learn more about partner types](/partner-center/membership/mpn-overview#services-partner) |
-| Premier or Unified Support Plan Members | Companies with a Premier or Unified Support contract are eligible| Contact your partner contact to request a subscription:</br> <ul><li>Customer Success Account Manager (CSAM) (for Premier or Unified Support customers)</li><li>Partner Development Manager (PDM) (for Managed Partners)<li>Customer Support Engineer (for ISV Partners)</li></ul> | N/A |
+| Premier or Unified Support Plan Members | Companies with a Premier or Unified Support contract are eligible.| To request a subscription, contact your partner contact:</br> <ul><li>Customer Success Account Manager (CSAM) (for Premier or Unified Support customers)</li><li>Partner Development Manager (PDM) (for Managed Partners)<li>Customer Support Engineer (for ISV Partners)</li></ul> | N/A |
+| Government clouds | The Microsoft 365 Developer Program is not offered in Microsoft's government clouds such as Microsoft 365 Government (GCC, GCC High, or DoD). | Government cloud environments are designed to meet specific regulatory and compliance requirements, and some programs or features available in the commercial cloud are not supported there. | N/A |
 
 ## Join the Microsoft 365 Developer Program
 


### PR DESCRIPTION
Reword eligibility criteria for Premier or Unified Support Plan Members and add a new entry for Government clouds.