### PR TITLE
Update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: ./
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check out main
@@ -35,4 +35,5 @@ jobs:
         run: |
           echo "Pushing changes to live branch"
           git push origin live
+
 


### PR DESCRIPTION
Updates the `actions/checkout` action in the auto-publish workflow from `v4` to `v6` for consistency with other repos that already use `v6`.