### PR TITLE
Clarify Azure subscription requirement for sandbox setup

### DIFF
--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -323,7 +323,7 @@ sections:
       - question: |
           Can I use an existing organizational billing account?
         answer: |
-          Yes. You can use an eligible organizational billing account or an eligible individual billing account. Enterprise users don't need to create a separate billing account if they have permission to use an existing organizational billing account, billing profile, and invoice section, and the account has an active Azure subscription associated through an Azure plan.
+          Yes. You can use an eligible organizational billing account or an eligible individual billing account. Enterprise users don't need to create a separate billing account if they have permission to use an existing organizational billing account, billing profile, and invoice section, and the account has an active Azure subscription created under the selected billing profile and invoice section with an Azure plan.
 
           If your organization manages billing centrally, contact your billing administrator to identify the billing account, billing profile, and invoice section that you are authorized to use. Don't create duplicate billing accounts to work around missing permissions.
 
@@ -342,7 +342,7 @@ sections:
           - **View Asset** — Permission to view assets associated with the billing entity.
           - **Add Asset (Write)** — Permission to create or add assets under the billing entity.
 
-          If the billing account doesn't have an active Azure subscription, [create an MCA subscription](/azure/cost-management-billing/manage/create-subscription) under its billing profile and invoice section through an Azure plan.
+          If the billing account doesn't have an active Azure subscription, [create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription) under the selected billing profile and invoice section with an Azure plan.
 
           After confirming the account requirements and permissions, return to sandbox setup and select the refresh icon next to the dropdown. For additional guidance, see [Billing account not appearing in the dropdown](microsoft-365-developer-program-get-started.md#billing-account-not-appearing-in-the-dropdown).
 
@@ -364,14 +364,14 @@ sections:
       - question: |
           What should I do if my billing account doesn't have an Azure subscription?
         answer: |
-          If you have a valid MCA billing account but no Azure subscription is associated with it, create an MCA subscription. During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan.
+          If you have a valid MCA billing account but no Azure subscription exists under it, create a Microsoft Customer Agreement subscription. During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan.
 
-          For instructions and required permissions, see [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription). After the Azure subscription is active and associated with the eligible billing account, return to the Developer Program dashboard and retry sandbox setup.
+          For instructions and required permissions, see [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription). After the Azure subscription is active under the eligible billing account, return to the Developer Program dashboard and retry sandbox setup.
 
       - question: |
           Why is the Set up button unavailable during billing configuration?
         answer: |
-          The **Set up** button remains unavailable until the **Billing account**, **Billing profile**, and **Invoice section** fields all contain valid selections. Confirm that the selected billing account meets the MCA and status requirements, has an active Azure subscription associated through an Azure plan, and has an active invoice section that you have permission to use.
+          The **Set up** button remains unavailable until the **Billing account**, **Billing profile**, and **Invoice section** fields all contain valid selections. Confirm that the selected billing account meets the MCA and status requirements, has an active Azure subscription created under the selected billing profile and invoice section with an Azure plan, and has an active invoice section that you have permission to use.
 
           If you recently created the billing account or received new permissions, select the refresh icon next to the **Billing account** dropdown and select the account again.
 
@@ -393,7 +393,7 @@ sections:
           - **Azure plan** — The plan selected when an Azure subscription is created that determines its pricing and service-level agreement.
           - **Azure subscription** — An Azure service container created under the selected billing account, billing profile, invoice section, and Azure plan.
 
-          Sandbox setup requires an active MCA billing account with an eligible billing profile, an active invoice section, and an active Azure subscription associated through an Azure plan. For more information, see [Get started with your Microsoft Customer Agreement billing account](/azure/cost-management-billing/understand/mca-overview) and [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
+          Sandbox setup requires an active MCA billing account with an eligible billing profile, an active invoice section, and an active Azure subscription created under the selected billing profile and invoice section with an Azure plan. For more information, see [Get started with your Microsoft Customer Agreement billing account](/azure/cost-management-billing/understand/mca-overview) and [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
 
       - question: |
           Does creating an Azure subscription or removing a spending limit create charges?
@@ -421,7 +421,7 @@ sections:
         answer: |
           Not until you have checked the existing account. Creating another billing account can result in duplicate billing structures and might not resolve an account, permission, or configuration problem.
 
-          Confirm that you're signed in with the correct account, that the billing account is active and uses an MCA, that an active Azure subscription is associated through an Azure plan and active invoice section, and that you have **View Asset** and **Add Asset (Write)** permissions. If your organization owns the account, contact its billing administrator instead of creating another account.
+          Confirm that you're signed in with the correct account, that the billing account is active and uses an MCA, that an active Azure subscription was created under the selected billing profile and active invoice section with an Azure plan, and that you have **View Asset** and **Add Asset (Write)** permissions. If your organization owns the account, contact its billing administrator instead of creating another account.
 
       - question: |
           What information should I provide to support for a billing setup failure?
@@ -433,7 +433,7 @@ sections:
           - The Developer Program account used during setup.
           - The selected billing account, billing profile, and invoice section names or masked identifiers.
           - The billing account agreement type and status.
-          - Whether an active Azure subscription is associated with the billing account and which Azure plan it uses.
+          - Whether an active Azure subscription was created under the billing account and which Azure plan it uses.
           - A screenshot showing the error and selected fields.
 
           Don't include payment card numbers, bank-account details, passwords, authentication codes, or other sensitive billing information.

--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -342,6 +342,8 @@ sections:
           - **View Asset** — Permission to view assets associated with the billing entity.
           - **Add Asset (Write)** — Permission to create or add assets under the billing entity.
 
+          If the billing account doesn't have an active Azure subscription, [create an MCA subscription](/azure/cost-management-billing/manage/create-subscription) under its billing profile and invoice section through an Azure plan.
+
           After confirming the account requirements and permissions, return to sandbox setup and select the refresh icon next to the dropdown. For additional guidance, see [Billing account not appearing in the dropdown](microsoft-365-developer-program-get-started.md#billing-account-not-appearing-in-the-dropdown).
 
       - question: |

--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -393,7 +393,7 @@ sections:
           - **Azure plan** — The plan selected when an Azure subscription is created that determines its pricing and service-level agreement.
           - **Azure subscription** — An Azure service container created under the selected billing account, billing profile, invoice section, and Azure plan.
 
-          Sandbox setup requires an active MCA billing account with an eligible billing profile, an active invoice section, and an active Azure subscription created under the selected billing profile and invoice section with an Azure plan. For more information, see [Get started with your Microsoft Customer Agreement billing account](/azure/cost-management-billing/understand/mca-overview) and [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
+          When you use an existing billing account for sandbox setup, it must be an active MCA billing account with an eligible billing profile, an active invoice section, and an active Azure subscription created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan. For more information, see [Get started with your Microsoft Customer Agreement billing account](/azure/cost-management-billing/understand/mca-overview) and [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
 
       - question: |
           Does creating an Azure subscription or removing a spending limit create charges?

--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -421,7 +421,7 @@ sections:
         answer: |
           Not until you have checked the existing account. Creating another billing account can result in duplicate billing structures and might not resolve an account, permission, or configuration problem.
 
-          Confirm that you're signed in with the correct account, that the billing account is active and uses an MCA, that an active Azure subscription was created under the selected billing profile and active invoice section with an Azure plan, and that you have **View Asset** and **Add Asset (Write)** permissions. If your organization owns the account, contact its billing administrator instead of creating another account.
+          Confirm that you're signed in with the correct account, that the billing account is active and uses an MCA, that an active Azure subscription was created with an Azure plan under the billing profile and active invoice section that you intend to use during sandbox setup, and that you have **View Asset** and **Add Asset (Write)** permissions. If your organization owns the account, contact its billing administrator instead of creating another account.
 
       - question: |
           What information should I provide to support for a billing setup failure?

--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -323,7 +323,7 @@ sections:
       - question: |
           Can I use an existing organizational billing account?
         answer: |
-          Yes. You can use an eligible organizational billing account or an eligible individual billing account. Enterprise users don't need to create a separate billing account if they have permission to use an existing organizational billing account, billing profile, and invoice section, and the account has an active Azure subscription created under the selected billing profile and invoice section with an Azure plan.
+          Yes. You can use an eligible organizational billing account or an eligible individual billing account. Enterprise users don't need to create a separate billing account if they have permission to use an existing organizational billing account, billing profile, and invoice section, and the account has an active Azure subscription created under the billing profile and invoice section that they intend to use during sandbox setup, with an Azure plan.
 
           If your organization manages billing centrally, contact your billing administrator to identify the billing account, billing profile, and invoice section that you are authorized to use. Don't create duplicate billing accounts to work around missing permissions.
 
@@ -334,7 +334,7 @@ sections:
 
           - Its agreement type is Microsoft Customer Agreement (MCA).
           - Its status is **Active**.
-          - It has at least one active Azure subscription created under a billing profile and invoice section through an Azure plan.
+          - It has at least one active Azure subscription created under a billing profile and invoice section with an Azure plan.
           - The billing profile contains at least one active invoice section.
 
           You must also have both of the following permissions on at least one invoice section in that billing account:

--- a/docs/microsoft-365-developer-program-faq.yml
+++ b/docs/microsoft-365-developer-program-faq.yml
@@ -2,7 +2,7 @@
 metadata:
   title: Microsoft 365 Developer Program FAQ
   description: Frequently asked questions about the Microsoft 365 Developer Program.
-  ms.date: 09/03/2026
+  ms.date: 09/04/2026
   ms.localizationpriority: high
 
 title: Microsoft 365 Developer Program FAQ
@@ -323,7 +323,7 @@ sections:
       - question: |
           Can I use an existing organizational billing account?
         answer: |
-          Yes. You can use an eligible organizational billing account or an eligible individual billing account. Enterprise users don't need to create a separate billing account if they have permission to use an existing organizational billing account, billing profile, and invoice section.
+          Yes. You can use an eligible organizational billing account or an eligible individual billing account. Enterprise users don't need to create a separate billing account if they have permission to use an existing organizational billing account, billing profile, and invoice section, and the account has an active Azure subscription associated through an Azure plan.
 
           If your organization manages billing centrally, contact your billing administrator to identify the billing account, billing profile, and invoice section that you are authorized to use. Don't create duplicate billing accounts to work around missing permissions.
 
@@ -334,7 +334,7 @@ sections:
 
           - Its agreement type is Microsoft Customer Agreement (MCA).
           - Its status is **Active**.
-          - It contains at least one billing profile with an Azure plan.
+          - It has at least one active Azure subscription created under a billing profile and invoice section through an Azure plan.
           - The billing profile contains at least one active invoice section.
 
           You must also have both of the following permissions on at least one invoice section in that billing account:
@@ -360,16 +360,16 @@ sections:
           For more information, see [Billing roles for Microsoft Customer Agreements](/azure/cost-management-billing/manage/understand-mca-roles).
 
       - question: |
-          What should I do if my billing account doesn't have an Azure plan?
+          What should I do if my billing account doesn't have an Azure subscription?
         answer: |
-          If you have a valid MCA billing account but no Azure plan is enabled on it, create an invoice section. This action might provision the required Azure plan.
+          If you have a valid MCA billing account but no Azure subscription is associated with it, create an MCA subscription. During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan.
 
-          For instructions, see [Organize your invoice based on your needs](/azure/cost-management-billing/manage/mca-section-invoice). After the invoice section is active and the Azure plan is available, return to the Developer Program dashboard and retry sandbox setup.
+          For instructions and required permissions, see [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription). After the Azure subscription is active and associated with the eligible billing account, return to the Developer Program dashboard and retry sandbox setup.
 
       - question: |
           Why is the Set up button unavailable during billing configuration?
         answer: |
-          The **Set up** button remains unavailable until the **Billing account**, **Billing profile**, and **Invoice section** fields all contain valid selections. Confirm that the selected billing account meets the MCA, status, Azure plan, and invoice-section requirements and that you have permission to use it.
+          The **Set up** button remains unavailable until the **Billing account**, **Billing profile**, and **Invoice section** fields all contain valid selections. Confirm that the selected billing account meets the MCA and status requirements, has an active Azure subscription associated through an Azure plan, and has an active invoice section that you have permission to use.
 
           If you recently created the billing account or received new permissions, select the refresh icon next to the **Billing account** dropdown and select the account again.
 
@@ -381,24 +381,25 @@ sections:
           Complete the agreement-signing process in the [Microsoft 365 admin center](https://admin.microsoft.com), then return to the Developer Program dashboard and retry sandbox setup.
 
       - question: |
-          What are a billing account, billing profile, invoice section, and Azure plan?
+          What are a billing account, billing profile, invoice section, Azure plan, and Azure subscription?
         answer: |
           These items form the billing structure used during sandbox verification:
 
           - **Billing account** — The top-level record that represents your agreement with Microsoft.
           - **Billing profile** — A record under the billing account that contains invoice and payment information.
           - **Invoice section** — A grouping under a billing profile that organizes purchases and charges.
-          - **Azure plan** — The plan under an MCA billing profile that enables Azure subscriptions and services.
+          - **Azure plan** — The plan selected when an Azure subscription is created that determines its pricing and service-level agreement.
+          - **Azure subscription** — An Azure service container created under the selected billing account, billing profile, invoice section, and Azure plan.
 
-          Sandbox setup requires an active MCA billing account with an eligible billing profile, an active invoice section, and an Azure plan. For more information about this structure, see [Organize your invoice based on your needs](/azure/cost-management-billing/manage/mca-section-invoice).
+          Sandbox setup requires an active MCA billing account with an eligible billing profile, an active invoice section, and an active Azure subscription associated through an Azure plan. For more information, see [Get started with your Microsoft Customer Agreement billing account](/azure/cost-management-billing/understand/mca-overview) and [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
 
       - question: |
-          Does enabling an Azure plan or removing a spending limit create charges?
+          Does creating an Azure subscription or removing a spending limit create charges?
         answer: |
-          Enabling an Azure plan, removing a spending limit, or creating billing records doesn't create a charge for the Microsoft 365 E5 developer sandbox. The sandbox remains free.
+          Creating an Azure subscription, selecting an Azure plan, removing a spending limit, or creating billing records doesn't create a charge for the Microsoft 365 E5 developer sandbox. The sandbox remains free. Charges are incurred only if an authorized user deploys paid Azure resources or intentionally purchases another paid product or service.
 
           > [!IMPORTANT]
-          > If you aren't the billing owner or don't understand the effect on an existing Azure subscription, stop and contact your organization's billing administrator before changing the Azure plan or spending limit.
+          > If you aren't the billing owner or don't understand the effect of creating or changing an Azure subscription, stop and contact your organization's billing administrator before creating the subscription, selecting an Azure plan, or removing a spending limit.
 
       - question: |
           What should I do after billing permissions are granted?
@@ -411,14 +412,14 @@ sections:
           4. If the account still doesn't appear, sign out of all Microsoft accounts, close the browser, and sign in again with the authorized account.
           5. Select the billing account, billing profile, and invoice section, and then retry setup.
 
-          If the account remains unavailable, verify its MCA agreement, status, Azure plan, and invoice section before contacting support.
+          If the account remains unavailable, verify its MCA agreement, status, active Azure subscription, Azure plan, and invoice section before contacting support.
 
       - question: |
           Should I create another billing account if my existing account isn't visible?
         answer: |
           Not until you have checked the existing account. Creating another billing account can result in duplicate billing structures and might not resolve an account, permission, or configuration problem.
 
-          Confirm that you're signed in with the correct account, that the billing account is active and uses an MCA, that an Azure plan and active invoice section exist, and that you have **View Asset** and **Add Asset (Write)** permissions. If your organization owns the account, contact its billing administrator instead of creating another account.
+          Confirm that you're signed in with the correct account, that the billing account is active and uses an MCA, that an active Azure subscription is associated through an Azure plan and active invoice section, and that you have **View Asset** and **Add Asset (Write)** permissions. If your organization owns the account, contact its billing administrator instead of creating another account.
 
       - question: |
           What information should I provide to support for a billing setup failure?
@@ -430,7 +431,7 @@ sections:
           - The Developer Program account used during setup.
           - The selected billing account, billing profile, and invoice section names or masked identifiers.
           - The billing account agreement type and status.
-          - Whether an Azure plan is enabled.
+          - Whether an active Azure subscription is associated with the billing account and which Azure plan it uses.
           - A screenshot showing the error and selected fields.
 
           Don't include payment card numbers, bank-account details, passwords, authentication codes, or other sensitive billing information.

--- a/docs/microsoft-365-developer-program-get-started.md
+++ b/docs/microsoft-365-developer-program-get-started.md
@@ -27,7 +27,7 @@ If you qualify for a Microsoft 365 E5 subscription through the developer program
 >
 > The billing account is used for verification and to enable future paid purchases. You will not be charged for the developer sandbox. Charges are incurred only if you intentionally purchase a paid product or service.
 >
-> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription has been created under the billing profile and invoice section that you intend to use during sandbox setup, with an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
+> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. If you plan to use an existing billing account, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription has been created under the billing profile and invoice section that you intend to use during sandbox setup, with an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
 >
 > If you already have an MCA billing account but it doesn't have an Azure subscription, [create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription). During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan. For all billing requirements, see [Configure billing details](#step-2-configure-billing-details).
 
@@ -56,7 +56,7 @@ Before you begin, make sure you have:
 
 - A Microsoft account to sign in with.
 - A valid individual or organizational billing account.
-- An active Azure subscription created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan.
+- For an existing billing account, an active Azure subscription created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan.
 - A business phone number and address, for billing account creation.
 
 ### Step 1: Choose your sandbox type
@@ -88,7 +88,7 @@ The billing account must meet the following requirements:
 
 - The Microsoft Customer Agreement (MCA) is accepted for an active billing account.
 - The billing profile and invoice section are active and available for you to use.
-- An active Azure subscription is created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan.
+- If you select an existing billing account, it has an active Azure subscription created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan.
 - The spending limit on any associated Azure subscription is removed.
 
 1. **Select country/region.** Choose the data center region closest to you from the **Country/region for your data center** dropdown.

--- a/docs/microsoft-365-developer-program-get-started.md
+++ b/docs/microsoft-365-developer-program-get-started.md
@@ -202,6 +202,8 @@ For resources to help you set up your development environment and deployment pip
 
 Choose the refresh icon next to the **Billing account** dropdown. Allow a few seconds after completing billing account creation before refreshing.
 
+If an existing MCA billing account doesn't appear, verify that an active Azure subscription is associated with its billing profile and invoice section through an Azure plan. If the account doesn't have an Azure subscription, follow the instructions in [No Azure subscription is associated with the billing account](#no-azure-subscription-is-associated-with-the-billing-account).
+
 If the billing account still doesn't appear, or if the system shows **BillingAccountAlreadyExists** or displays "Your billing account is ready," check for the following:
 
 #### You don't have permission to use an organizational billing account

--- a/docs/microsoft-365-developer-program-get-started.md
+++ b/docs/microsoft-365-developer-program-get-started.md
@@ -27,9 +27,9 @@ If you qualify for a Microsoft 365 E5 subscription through the developer program
 >
 > The billing account is used for verification and to enable future paid purchases. You will not be charged for the developer sandbox. Charges are incurred only if you intentionally purchase a paid product or service.
 >
-> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions) is enabled, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) is removed.
+> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription is associated with them through an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
 >
-> If your MCA billing account doesn't have an Azure plan, create an invoice section. This action might provision the required Azure plan. For instructions, see [Organize your invoice based on your needs](/azure/cost-management-billing/manage/mca-section-invoice). For all billing requirements, see [Configure billing details](#step-2-configure-billing-details).
+> If you already have an MCA billing account but it doesn't have an Azure subscription, [create an MCA subscription](/azure/cost-management-billing/manage/create-subscription). During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan. For all billing requirements, see [Configure billing details](#step-2-configure-billing-details).
 
 ## Instant sandbox
 
@@ -56,6 +56,7 @@ Before you begin, make sure you have:
 
 - A Microsoft account to sign in with.
 - A valid individual or organizational billing account.
+- An active Azure subscription associated with the billing account through a billing profile, invoice section, and Azure plan.
 - A business phone number and address, for billing account creation.
 
 ### Step 1: Choose your sandbox type
@@ -87,7 +88,7 @@ The billing account must meet the following requirements:
 
 - The Microsoft Customer Agreement (MCA) is accepted for an active billing account.
 - The billing profile and invoice section are active and available for you to use.
-- The Azure plan is enabled.
+- An active Azure subscription is associated with the billing account, billing profile, and invoice section through an Azure plan.
 - The spending limit on any associated Azure subscription is removed.
 
 1. **Select country/region.** Choose the data center region closest to you from the **Country/region for your data center** dropdown.
@@ -209,13 +210,13 @@ An organizational billing account appears only if your signed-in account has per
 
 For information about billing permissions, see [Billing roles for Microsoft Customer Agreements](/azure/cost-management-billing/manage/understand-mca-roles).
 
-#### No Azure plan is enabled on the account
+#### No Azure subscription is associated with the billing account
 
-If you have a valid MCA billing account but no Azure plan is enabled on it, create an invoice section. This action might provision the required Azure plan.
+If you have a valid MCA billing account but no Azure subscription is associated with it, create an MCA subscription. During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan.
 
-For instructions, see [Organize your invoice based on your needs](/azure/cost-management-billing/manage/mca-section-invoice).
+For instructions and required permissions, see [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
 
-After the invoice section has been created and the Azure plan is available, attempt the setup again.
+After the Azure subscription is active and associated with the eligible billing account, attempt the setup again.
 
 #### A spending limit is enabled
 

--- a/docs/microsoft-365-developer-program-get-started.md
+++ b/docs/microsoft-365-developer-program-get-started.md
@@ -27,7 +27,7 @@ If you qualify for a Microsoft 365 E5 subscription through the developer program
 >
 > The billing account is used for verification and to enable future paid purchases. You will not be charged for the developer sandbox. Charges are incurred only if you intentionally purchase a paid product or service.
 >
-> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription has been created under the selected billing profile and invoice section with an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
+> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription has been created under the billing profile and invoice section that you intend to use during sandbox setup, with an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
 >
 > If you already have an MCA billing account but it doesn't have an Azure subscription, [create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription). During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan. For all billing requirements, see [Configure billing details](#step-2-configure-billing-details).
 
@@ -56,7 +56,7 @@ Before you begin, make sure you have:
 
 - A Microsoft account to sign in with.
 - A valid individual or organizational billing account.
-- An active Azure subscription created under the billing account's selected billing profile and invoice section with an Azure plan.
+- An active Azure subscription created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan.
 - A business phone number and address, for billing account creation.
 
 ### Step 1: Choose your sandbox type
@@ -88,7 +88,7 @@ The billing account must meet the following requirements:
 
 - The Microsoft Customer Agreement (MCA) is accepted for an active billing account.
 - The billing profile and invoice section are active and available for you to use.
-- An active Azure subscription is created under the selected billing profile and invoice section with an Azure plan.
+- An active Azure subscription is created under the billing profile and invoice section that you intend to use during sandbox setup, with an Azure plan.
 - The spending limit on any associated Azure subscription is removed.
 
 1. **Select country/region.** Choose the data center region closest to you from the **Country/region for your data center** dropdown.

--- a/docs/microsoft-365-developer-program-get-started.md
+++ b/docs/microsoft-365-developer-program-get-started.md
@@ -27,9 +27,9 @@ If you qualify for a Microsoft 365 E5 subscription through the developer program
 >
 > The billing account is used for verification and to enable future paid purchases. You will not be charged for the developer sandbox. Charges are incurred only if you intentionally purchase a paid product or service.
 >
-> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription is associated with them through an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
+> You can use an eligible individual billing account or, if you have the required permissions, an existing organizational billing account. Before you begin, make sure that the [Microsoft Customer Agreement (MCA)](/azure/cost-management-billing/understand/mca-overview#check-access-to-a-microsoft-customer-agreement) is accepted, the [billing profile and invoice section](/azure/cost-management-billing/understand/mca-overview#your-billing-account) are active, and an active Azure subscription has been created under the selected billing profile and invoice section with an [Azure plan](/azure/cost-management-billing/understand/mca-overview#azure-plans-determine-pricing-and-service-level-agreement-for-subscriptions). Any applicable [Azure subscription spending limit](/azure/cost-management-billing/manage/spending-limit#remove-the-spending-limit-in-azure-portal) must also be removed.
 >
-> If you already have an MCA billing account but it doesn't have an Azure subscription, [create an MCA subscription](/azure/cost-management-billing/manage/create-subscription). During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan. For all billing requirements, see [Configure billing details](#step-2-configure-billing-details).
+> If you already have an MCA billing account but it doesn't have an Azure subscription, [create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription). During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan. For all billing requirements, see [Configure billing details](#step-2-configure-billing-details).
 
 ## Instant sandbox
 
@@ -56,7 +56,7 @@ Before you begin, make sure you have:
 
 - A Microsoft account to sign in with.
 - A valid individual or organizational billing account.
-- An active Azure subscription associated with the billing account through a billing profile, invoice section, and Azure plan.
+- An active Azure subscription created under the billing account's selected billing profile and invoice section with an Azure plan.
 - A business phone number and address, for billing account creation.
 
 ### Step 1: Choose your sandbox type
@@ -88,7 +88,7 @@ The billing account must meet the following requirements:
 
 - The Microsoft Customer Agreement (MCA) is accepted for an active billing account.
 - The billing profile and invoice section are active and available for you to use.
-- An active Azure subscription is associated with the billing account, billing profile, and invoice section through an Azure plan.
+- An active Azure subscription is created under the selected billing profile and invoice section with an Azure plan.
 - The spending limit on any associated Azure subscription is removed.
 
 1. **Select country/region.** Choose the data center region closest to you from the **Country/region for your data center** dropdown.
@@ -202,7 +202,7 @@ For resources to help you set up your development environment and deployment pip
 
 Choose the refresh icon next to the **Billing account** dropdown. Allow a few seconds after completing billing account creation before refreshing.
 
-If an existing MCA billing account doesn't appear, verify that an active Azure subscription is associated with its billing profile and invoice section through an Azure plan. If the account doesn't have an Azure subscription, follow the instructions in [No Azure subscription is associated with the billing account](#no-azure-subscription-is-associated-with-the-billing-account).
+If an existing MCA billing account doesn't appear, verify that an active Azure subscription was created under its selected billing profile and invoice section with an Azure plan. If the account doesn't have an Azure subscription, follow the instructions in [No Azure subscription exists under the billing account](#no-azure-subscription-exists-under-the-billing-account).
 
 If the billing account still doesn't appear, or if the system shows **BillingAccountAlreadyExists** or displays "Your billing account is ready," check for the following:
 
@@ -212,17 +212,17 @@ An organizational billing account appears only if your signed-in account has per
 
 For information about billing permissions, see [Billing roles for Microsoft Customer Agreements](/azure/cost-management-billing/manage/understand-mca-roles).
 
-#### No Azure subscription is associated with the billing account
+#### No Azure subscription exists under the billing account
 
-If you have a valid MCA billing account but no Azure subscription is associated with it, create an MCA subscription. During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan.
+If you have a valid MCA billing account but no Azure subscription exists under it, create a Microsoft Customer Agreement subscription. During creation, select the eligible billing account, billing profile, invoice section, and appropriate Azure plan.
 
 For instructions and required permissions, see [Create a Microsoft Customer Agreement subscription](/azure/cost-management-billing/manage/create-subscription).
 
-After the Azure subscription is active and associated with the eligible billing account, attempt the setup again.
+After the Azure subscription is active under the eligible billing account, attempt the setup again.
 
 #### A spending limit is enabled
 
-If a spending limit applies to the Azure subscription associated with the billing account, remove the spending limit, then retry sandbox setup. You must have the required billing permissions and a valid payment method to remove it.
+If a spending limit applies to the Azure subscription created under the billing account, remove the spending limit, then retry sandbox setup. You must have the required billing permissions and a valid payment method to remove it.
 
 For instructions, see [Azure spending limit](/azure/cost-management-billing/manage/spending-limit).
 

--- a/docs/microsoft-365-developer-program-get-started.md
+++ b/docs/microsoft-365-developer-program-get-started.md
@@ -202,7 +202,7 @@ For resources to help you set up your development environment and deployment pip
 
 Choose the refresh icon next to the **Billing account** dropdown. Allow a few seconds after completing billing account creation before refreshing.
 
-If an existing MCA billing account doesn't appear, verify that an active Azure subscription was created under its selected billing profile and invoice section with an Azure plan. If the account doesn't have an Azure subscription, follow the instructions in [No Azure subscription exists under the billing account](#no-azure-subscription-exists-under-the-billing-account).
+If an existing MCA billing account doesn't appear, verify that an active Azure subscription was created with an Azure plan under the billing profile and invoice section that you intend to use during sandbox setup. If the account doesn't have an Azure subscription, follow the instructions in [No Azure subscription exists under the billing account](#no-azure-subscription-exists-under-the-billing-account).
 
 If the billing account still doesn't appear, or if the system shows **BillingAccountAlreadyExists** or displays "Your billing account is ready," check for the following:
 


### PR DESCRIPTION
## Summary

- clarify that an active Azure subscription is required for an existing MCA billing account
- explain that the subscription must be associated with the selected billing profile, invoice section, and Azure plan
- replace the previous invoice-section-only workaround with the official MCA subscription creation flow
- add the Microsoft Learn subscription-creation reference throughout setup and troubleshooting guidance
- clarify that creating the subscription does not itself charge for the Microsoft 365 developer sandbox

## Validation

- `git diff --check`